### PR TITLE
TPNGSpeedButton.Paint Calculate the GlyphPos and TextPos before calling inherited Paint

### DIFF
--- a/Source/PngSpeedButton.pas
+++ b/Source/PngSpeedButton.pas
@@ -72,12 +72,18 @@ var
   PaintRect: TRect;
   GlyphPos, TextPos: TPoint;
 begin
+  { Something happens in the inherited Paint call which breaks the GlyphPos and TextPos calculation}
+  if HasValidPng then
+    //Calculate the position of the PNG glyph
+    CalcButtonLayout(Canvas, FPngImage, ClientRect, FState = bsDown, Down,
+      Caption, Layout, Margin, Spacing, GlyphPos, TextPos, DrawTextBiDiModeFlags(0));
+
   inherited Paint;
 
   if HasValidPng then begin
     //Calculate the position of the PNG glyph
-    CalcButtonLayout(Canvas, FPngImage, ClientRect, FState = bsDown, Down,
-      Caption, Layout, Margin, Spacing, GlyphPos, TextPos, DrawTextBiDiModeFlags(0));
+    //CalcButtonLayout(Canvas, FPngImage, ClientRect, FState = bsDown, Down,
+    //  Caption, Layout, Margin, Spacing, GlyphPos, TextPos, DrawTextBiDiModeFlags(0));
     PaintRect := Bounds(GlyphPos.X, GlyphPos.Y, FPngImage.Width, FPngImage.Height);
 
     if csLoading in ComponentState then Exit;


### PR DESCRIPTION
With the TPngSpeedButton I noticed that the image wasn't drawing in the same position it used to, while the TPngBitBtn was still drawing fine. At first I thought there was an issue with CalcButtonLayout as the version in PngButtonFunctions is different to the one in Vcl.Buttons.TButtonGlyph, but that isn't the case.

If I step into the `inherited Create;` call then the internal calculations in Vcl.Buttons.TButtonGlyph.CalcButtonLayout(...) produce the same results as TPngBitBtn.CNDrawItem calling PngButtonFunctions.CalcButtonLayout(...).

Simply moving the CalcButtonLayout call in TPngSpeedButton.Paint before the `inherited Create;` fixes the drawing issue. I couldn't figure out what might have changed to cause the calculation to differ.

If you would like this solved in another way let me know.

Simple Test form with 2 buttons attached
[Unit1.zip](https://github.com/UweRaabe/PngComponents/files/5449884/Unit1.zip)

