### PR TITLE
Small adjustments for compatibility with Delphi 2007 and earlier

### DIFF
--- a/Source/PngFunctions.pas
+++ b/Source/PngFunctions.pas
@@ -518,6 +518,6 @@ initialization
   TPicture.RegisterFileFormat('', '', TPNGObject);
 finalization
   TPicture.UnregisterGraphicClass(TPNGObject);
-{$IFEND}
+{$ENDIF}
 {$IFEND}
 end.

--- a/Source/PngImageList.pas
+++ b/Source/PngImageList.pas
@@ -10,13 +10,13 @@ uses
   Windows, Classes, SysUtils, Controls, Graphics, ImgList,
   {$IF CompilerVersion >= 34.0 Delphi 10.4 }
   System.UITypes,
-  {$ENDIF}
+  {$IFEND}
   PngImage, PngFunctions;
 
 {$IF CompilerVersion < 34.0 Delphi 10.4 }
 type
   TImageName = type string;
-{$ENDIF}
+{$IFEND}
 
 type
   INameMapping = interface
@@ -75,7 +75,7 @@ type
     {$IF CompilerVersion >= 34.0 Delphi 10.4 Sydney }
     function AddDisabledImage(Value: TCustomImageList; Index: Integer): Integer; virtual;
     procedure AddDisabledImages(Value: TCustomImageList); virtual;
-    {$ENDIF}
+    {$IFEND}
     procedure Assign(Source: TPersistent); override;
     procedure BeginUpdate;
     procedure Clear; virtual;
@@ -94,9 +94,9 @@ type
     procedure ReplaceMasked(Index: Integer; NewImage: TBitmap; MaskColor: TColor); virtual;
     {$IF CompilerVersion >= 34.0 Delphi 10.4 }
     function IsImageNameAvailable: Boolean; override;
-    {$ENDIF}
-    function GetIndexByName(const AName: TImageName): TImageIndex; {$IF CompilerVersion >= 34.0 Delphi 10.4 }override;{$ENDIF}
-    function GetNameByIndex(AIndex: TImageIndex): TImageName; {$IF CompilerVersion >= 34.0 Delphi 10.4 }override;{$ENDIF}
+    {$IFEND}
+    function GetIndexByName(const AName: TImageName): TImageIndex; {$IF CompilerVersion >= 34.0 Delphi 10.4 }override;{$IFEND}
+    function GetNameByIndex(AIndex: TImageIndex): TImageName; {$IF CompilerVersion >= 34.0 Delphi 10.4 }override;{$IFEND}
     property ImageName[Index: Integer]: string read GetImageName;
   published
     property ColorDepth default cd32Bit;
@@ -265,7 +265,7 @@ begin
     SetLength(Pointers, 17);
     {$ELSE}
     SetLength(Pointers, 15);
-    {$ENDIF}
+    {$IFEND}
     Pointers[0] := Combo(@TCustomImageList.Add, @TPngImageList.Add, 'Add');
     Pointers[1] := Combo(@TCustomImageList.AddIcon, @TPngImageList.AddIcon, 'AddIcon');
     Pointers[2] := Combo(@TCustomImageList.AddImage, @TPngImageList.AddImage, 'AddImage');
@@ -284,7 +284,7 @@ begin
     {$IF CompilerVersion >= 34.0 Delphi 10.4 Sydney }
     Pointers[15] := Combo(@TCustomImageList.AddDisabledImage, @TPngImageList.AddDisabledImage, 'AddDisabledImage');
     Pointers[16] := Combo(@TCustomImageList.AddDisabledImages, @TPngImageList.AddDisabledImages, 'AddDisabledImages');
-    {$ENDIF}
+    {$IFEND}
 
     MethodPatches := TObjectList.Create;
     for I := Low(Pointers) to High(Pointers) do begin
@@ -398,7 +398,7 @@ begin
   inherited Create(AOwner);
   {$IF CompilerVersion >= 33.0 Delphi 10.3 Rio }
   StoreBitmap := False;
-  {$ENDIF}
+  {$IFEND}
   FImageNameAvailable := False;
   ColorDepth := cd32Bit;
   if ImageListCount = 0 then
@@ -641,7 +641,7 @@ begin
     end;
   end;
 end;
-{$ENDIF}
+{$IFEND}
 
 function TPngImageList.AddMasked(Image: TBitmap; MaskColor: TColor): Integer;
 var
@@ -898,7 +898,7 @@ function TPngImageList.IsImageNameAvailable: Boolean;
 begin
   Result := FImageNameAvailable;
 end;
-{$ENDIF}
+{$IFEND}
 
 function TPngImageList.GetIndexByName(const AName: TImageName): TImageIndex;
 begin

--- a/Source/PngImageList.pas
+++ b/Source/PngImageList.pas
@@ -99,7 +99,9 @@ type
     function GetNameByIndex(AIndex: TImageIndex): TImageName; {$IF CompilerVersion >= 34.0 Delphi 10.4 }override;{$IFEND}
     property ImageName[Index: Integer]: string read GetImageName;
   published
+    {$IF CompilerVersion >= 20.0 Delphi 2009 }
     property ColorDepth default cd32Bit;
+    {$IFEND}
     property EnabledImages: Boolean read FEnabledImages write SetEnabledImages default True;
     property Height read GetHeight write SetHeight default 16;
     property ImageNameAvailable: Boolean read FImageNameAvailable write FImageNameAvailable default False;
@@ -400,7 +402,9 @@ begin
   StoreBitmap := False;
   {$IFEND}
   FImageNameAvailable := False;
+  {$IF CompilerVersion >= 20.0 Delphi 2009 }
   ColorDepth := cd32Bit;
+  {$IFEND}
   if ImageListCount = 0 then
     ApplyMethodPatches;
   Inc(ImageListCount);
@@ -688,9 +692,11 @@ begin
     end;
   end;
 
+  {$IF CompilerVersion >= 20.0 Delphi 2009 }
   if Source is TCustomImageList then begin
     ColorDepth := TCustomImageList(Source).ColorDepth;
   end;
+  {$IFEND}
 
   inherited;
 end;


### PR DESCRIPTION
Updates {$ENDIF} compiler directives that follow an {$IF ...} to use {$IFEND} instead.
Hides the ColorDepth property as it does not exist in the TImageList parent class in Delphi 2007 and earlier versions.